### PR TITLE
Additional keys and log message added

### DIFF
--- a/OpenVR2Key/App.config
+++ b/OpenVR2Key/App.config
@@ -23,7 +23,7 @@
                 <value>False</value>
             </setting>
             <setting name="Version" serializeAs="String">
-                <value>v0.43</value>
+                <value>v0.44</value>
             </setting>
         </OpenVR2Key.Properties.Settings>
     </userSettings>

--- a/OpenVR2Key/MainController.cs
+++ b/OpenVR2Key/MainController.cs
@@ -94,15 +94,20 @@ namespace OpenVR2Key
         }
 
         // Add incoming keys to the current binding
-        public void OnKeyDown(Key key)
+        public bool OnKeyDown(Key key)
         {
+            if (_registeringElement == null) return true;
             if (MainUtils.MatchVirtualKey(key) != null)
             {
-                if (_registeringElement == null) return;
                 if (_keysDown.Count == 0) _keys.Clear();
                 _keys.Add(key);
                 _keysDown.Add(key);
                 UpdateCurrentObject();
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
         public void OnKeyUp(Key key)

--- a/OpenVR2Key/MainUtils.cs
+++ b/OpenVR2Key/MainUtils.cs
@@ -33,7 +33,12 @@ namespace OpenVR2Key
             { Key.OemComma, VirtualKeyCode.OEM_COMMA },
             { Key.OemMinus, VirtualKeyCode.OEM_MINUS},
             { Key.OemPeriod, VirtualKeyCode.OEM_PERIOD},
-            { Key.OemPlus, VirtualKeyCode.OEM_PLUS}
+            { Key.OemPlus, VirtualKeyCode.OEM_PLUS},
+            // Keys added [ = '
+            { Key.OemOpenBrackets, VirtualKeyCode.OEM_4},
+            { Key.OemQuestion, VirtualKeyCode.OEM_2},
+            { Key.OemQuotes, VirtualKeyCode.OEM_7}
+
         };
 
         /**
@@ -45,8 +50,16 @@ namespace OpenVR2Key
             var keyStr = key.ToString().ToUpper();
 
             // Check for direct translation
-            if (translationTableKeys.ContainsKey(key)) return new Tuple<VirtualKeyCode, bool>(translationTableKeys[key], false);
-            if (translationTableModifiers.ContainsKey(key)) return new Tuple<VirtualKeyCode, bool>(translationTableModifiers[key], true);
+            if (translationTableKeys.ContainsKey(key))
+                return new Tuple<VirtualKeyCode, bool>(translationTableKeys[key], false);
+
+            // Check for translation as modifier key
+            if (translationTableModifiers.ContainsKey(key))
+                return new Tuple<VirtualKeyCode, bool>(translationTableModifiers[key], true);
+
+
+            // Check for translation using some rules based on how GregsStack names the keys
+            // Looks related to this info: http://www.kbdedit.com/manual/low_level_vk_list.html
 
             // Character keys which come in as A-Z
             if (keyStr.Length == 1) keyStr = $"VK_{keyStr}";
@@ -54,11 +67,14 @@ namespace OpenVR2Key
             // Number keys which come in as D0-D9
             else if (keyStr.Length == 2 && keyStr[0] == 'D' && Char.IsDigit(keyStr[1])) keyStr = $"VK_{keyStr[1]}";
 
-            // OEM Number keys
+            // OEM Number keys (these are weird and some require direct mapping from translation dictionaries translationTables above)
             else if (keyStr.StartsWith("OEM") && (int.TryParse(keyStr.Substring(3), out _))) keyStr = $"OEM_{keyStr.Substring(3)}";
 
             var success = Enum.TryParse(keyStr, out VirtualKeyCode result);
+            if (!success)
+                Debug.WriteLine("Key not found.");
             return success ? new Tuple<VirtualKeyCode, bool>(result, false) : null;
+            // If no key found, returns null
         }
 
         /**

--- a/OpenVR2Key/MainWindow.xaml.cs
+++ b/OpenVR2Key/MainWindow.xaml.cs
@@ -209,7 +209,20 @@ namespace OpenVR2Key
         {
             e.Handled = true;
             var key = e.Key == Key.System ? e.SystemKey : e.Key;
-            _controller.OnKeyDown(key);
+            if (!_controller.OnKeyDown(key))
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    string message = $"Key not mapped: " + key.ToString();
+                    var time = DateTime.Now.ToString("HH:mm:ss");
+                    var oldLog = TextBox_Log.Text;
+                    var lines = oldLog.Split('\n');
+                    Array.Resize(ref lines, 3);
+                    var newLog = string.Join("\n", lines);
+                    TextBox_Log.Text = $"{time}: {message}\n{newLog}";
+                });
+            }
+
         }
 
         // All key up events in the app

--- a/OpenVR2Key/OpenVR2Key.csproj
+++ b/OpenVR2Key/OpenVR2Key.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.Toolset.3.5.0\build\Microsoft.Net.Compilers.Toolset.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.Toolset.3.5.0\build\Microsoft.Net.Compilers.Toolset.props')" />
   <Import Project="..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props" Condition="Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -74,6 +75,9 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -168,6 +172,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.4.1.0\build\Costura.Fody.props'))" />
     <Error Condition="!Exists('..\packages\Fody.6.1.1\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.6.1.1\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.Toolset.3.5.0\build\Microsoft.Net.Compilers.Toolset.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.Toolset.3.5.0\build\Microsoft.Net.Compilers.Toolset.props'))" />
   </Target>
   <Import Project="..\packages\Fody.6.1.1\build\Fody.targets" Condition="Exists('..\packages\Fody.6.1.1\build\Fody.targets')" />
 </Project>

--- a/OpenVR2Key/packages.config
+++ b/OpenVR2Key/packages.config
@@ -3,5 +3,6 @@
   <package id="Costura.Fody" version="4.1.0" targetFramework="net472" />
   <package id="Fody" version="6.1.1" targetFramework="net472" developmentDependency="true" />
   <package id="GregsStack.InputSimulatorStandard" version="1.1.1" targetFramework="net472" />
+  <package id="Microsoft.Net.Compilers.Toolset" version="3.5.0" targetFramework="net472" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
I added a log message when a key is pressed that can't be found in the translation tables and added a few keys that were missing on my keyboard (open bracket, equal sign, single quote).