### PR TITLE
Update setup-dotnet to latest versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
           dotnet-quality: ga


### PR DESCRIPTION
This should remove the deprecated nodejs version warning.